### PR TITLE
 Add examples to README and a note highlighting that lastLocation != previous browser history state

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,34 @@
 
 [![Edit react-router-last-location](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/zn208l91zp)
 
+## Note: Last location != Previous browser history state
+
+This library only returns the location that has been active before the recent location change in the current window lifetime.
+
+This means, it is not equal to the "location that happened before navigating to this history state", or in other words "location to which you'll be redirected upon clicking browser back button".
+
+Example 1:
+
+1. Visit `/`: last location = `null`, previous browser history state = `null`
+2. Visit `/a`: last location = `/`, previous browser history state = `/`
+3. Visit `/b`: last location = `/a`, previous browser history state = `/a`
+4. Reload (url will stay at `/b`): last location = `null`, previous browser history state = `/a`
+
+Example 2:
+
+1. Visit `/`: last location = `null`
+2. Visit `/a`: last location = `/`
+3. Visit `/b`: last location = `/a`
+4. Go back: last location = `/b`, previous browser history state = `/`
+
+Example 3:
+
+1. Visit `/`: last location = `null`
+2. Visit `/a`: last location = `/`
+3. Visit `/b`: last location = `/a`
+4. Visit `/c`: last location = `/b`
+4. Go back to `/a` (by selecting that state explicitly in "Go back" browser dropdown that is visible upon clicking it with right mouse button): last location = `/c`, previous browser history state = `/`
+
 ## How to use?
 
 ```bash


### PR DESCRIPTION
Explains https://github.com/hinok/react-router-last-location/issues/18 .

Maybe we could make the last location to point to the previous browser history state, but:
- that would require keeping the previous history states in the history state `state` object
- would be way different behaviour than the current one
- nevertheless, even if we want to make it, it's worthy to keep this README note for now, so it's clear for all the users of it, what is it doing.