### PR TITLE
Explicitly Support React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6.0",
-    "react": "^15.5.4 || ^16.0.0",
-    "react-dom": "^15.5.4 || ^16.0.0",
+    "react": "^15.5.4 || ^16.0.0 || ^17.0.0",
+    "react-dom": "^15.5.4 || ^16.0.0 || ^17.0.0",
     "react-router-dom": "^4.1.1 || ^5.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
@hinok resolves #46.

With #57 merged, I believe the code itself and the tooling in the repo now supports React 17.